### PR TITLE
no ERC20.ovm.json

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -3,6 +3,8 @@ import { HardhatUserConfig } from 'hardhat/types'
 import '@nomiclabs/hardhat-ethers'
 import '@nomiclabs/hardhat-waffle'
 
+import '@eth-optimism/plugins/hardhat/compiler'
+
 const config: HardhatUserConfig = {
   solidity: "0.7.3",
 };

--- a/package.json
+++ b/package.json
@@ -22,5 +22,8 @@
     "rimraf": "^3.0.2",
     "ts-node": "^9.1.1",
     "typescript": "^4.1.3"
+  },
+  "dependencies": {
+    "@eth-optimism/plugins": "^1.0.0-alpha.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,6 +23,13 @@
   resolved "https://registry.yarnpkg.com/@eth-optimism/dev/-/dev-1.0.0.tgz#6a8ba479abe9a87fc689ba7bc6d23365f90b3a00"
   integrity sha512-btafO+VcHrWND3giztLo08LAaVx7k9UIODU0NEgw6NR2XvSZpcTbXf0xb4RDCMxwpmkbZc5gpyHrP72Uk9xSxw==
 
+"@eth-optimism/plugins@^1.0.0-alpha.2":
+  version "1.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/@eth-optimism/plugins/-/plugins-1.0.0-alpha.2.tgz#dc5ad1395944d63e6a592832b2360be59481e092"
+  integrity sha512-OrwMtgJuO4gZjCJX9rtZZQr3Fn+ksbhF9nKyB4+qggJXoatkJmj1+2UHNzuhfG2LaRu35PmJQYiV316K1YTyeg==
+  dependencies:
+    node-fetch "^2.6.1"
+
 "@ethereum-waffle/chai@^3.2.1":
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/@ethereum-waffle/chai/-/chai-3.2.1.tgz#5cb542b2a323adf0bc2dda00f48b0eb85944d8ab"
@@ -5059,7 +5066,7 @@ node-fetch@2.1.2:
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
   integrity sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=
 
-node-fetch@^2.6.0:
+node-fetch@^2.6.0, node-fetch@^2.6.1:
   version "2.6.1"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.1.tgz#045bd323631f76ed2e2b55573394416b639a0052"
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==


### PR DESCRIPTION
This is not really a pull request, just demonstrating a problem.

After adding the changes described in http://community.optimism.io/tutorial/#making-it-optimistic, I'm not seeing `artifacts/contracts/ERC20.sol/ERC20.ovm.json`

```
yarn versions v1.22.10
warning ../../package.json: No license field
{
  yarn: '1.22.10',
  'optimism-tutorial': '1.0.0',
  node: '15.12.0',
  v8: '8.6.395.17-node.27',
  uv: '1.41.0',
  zlib: '1.2.11',
  brotli: '1.0.9',
  ares: '1.17.1',
  modules: '88',
  nghttp2: '1.42.0',
  napi: '8',
  llhttp: '2.1.3',
  openssl: '1.1.1j+quic',
  cldr: '38.1',
  icu: '68.2',
  tz: '2020d',
  unicode: '13.0'
}
```
