### PR TITLE
Correct the version number of plugins library, so that ovm contract is compiled

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ We'll need to add a special plugin to hardhat that enables this custom Optimism 
 First, add the Optimism plugins package to your project:
 
 ```sh
-yarn add @eth-optimism/plugins
+yarn add @eth-optimism/plugins@v0.0.20
 ```
 
 Next, add the following line to [`optimism-tutorial/hardhat.config.ts`](https://github.com/ethereum-optimism/optimism-tutorial/blob/main/hardhat.config.ts):


### PR DESCRIPTION
<!--
Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
Correct the version number of plugins library, so that ovm contract is compiled

**Additional context**
Earlier the `yarn add` installed the latest tag which does not compile the OVM contracts
This will force to install a specific version of plugins

**Metadata**
- Fixes #[Link to Issue]
