### PR TITLE
Changed the git clone for optimism

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ Please note that `docker-compose build` *will* take a while.
 We're working on improving this (sorry)!
 
 ```sh
-git clone git@github.com:ethereum-optimism/optimism.git
+git clone https://github.com/ethereum-optimism/optimism.git
 cd optimism
 yarn install
 yarn build


### PR DESCRIPTION


**Description**
The old one required authentication. This one does not.

**Additional context**

`git clone git@github.com:ethereum-optimism/optimism.git` requires you to authenticate to github, or at least to have a private key for authenticating. That's not as easy as it can be if you don't require authentication. 
