### PR TITLE
Added docker-compose to the requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Please make sure you've installed the following before continuing:
 - [Node.js](https://nodejs.org/en/download/)
 - [Yarn](https://classic.yarnpkg.com/en/docs/install#mac-stable)
 - [Docker](https://docs.docker.com/engine/install/)
+- [Docker-compose](https://docs.docker.com/compose/install/)
 
 ## Setting Up
 


### PR DESCRIPTION
By default installing docker doesn't install docker-compose, at least when following the directions for Debian.