### PR TITLE
Add how to use Optimistic Kovan from Hardhat

### DIFF
--- a/hardhat/README.md
+++ b/hardhat/README.md
@@ -11,9 +11,11 @@ running on top of Optimistic Ethereum are about as secure as those running on th
 
 ## Build an Optimistic Ethereum Node
 
-The fastest way to test and debug apps on Optimistic Ethereum is to run a local Optimistic Ethereum node, so we'll build one.
-The directions in this section are for an Ubuntu 20.04 VM running on GCP with a 20 GB disk (the default, 10 GB, is not enough), 
-but they should be similar for other Linux versions and other platforms
+The fastest way to test and debug apps on Optimistic Ethereum is to run a 
+local Optimistic Ethereum node, so we'll build one.
+The directions in this section are for an Ubuntu 20.04 VM running on GCP with 
+a 20 GB disk (the default, 10 GB, is not enough) and 16 GB RAM
+but they should be similar for other Linux versions and other platforms.
 
 ### Install Prerequisite Software
 

--- a/hardhat/README.md
+++ b/hardhat/README.md
@@ -239,6 +239,20 @@ To solve this problem:
    npx hardhat --network optimistic test
    ```
 
+## Deploying to a Real Network
+
+To deploy to a real network (Optimistic Ethereum or Optimistic Kovan),
+edit `hardhat.config.js`'s `modules.export.networks` to add a definition
+similar to this one:
+
+```javascript
+    optimisticKovan: {
+       url: 'https://kovan.optimism.io',
+       accounts: { mnemonic: <your account mnemonic goes here> },
+       gasPrice: 15000000,
+       ovm: true // This sets the network as using the ovm and ensure contract will be compiled against that.
+    }
+```    
 
 ## Best Practices for Running Tests
 

--- a/hardhat/dapp/hardhat.config.js
+++ b/hardhat/dapp/hardhat.config.js
@@ -27,7 +27,14 @@ module.exports = {
        accounts: { mnemonic: 'test test test test test test test test test test test junk' },
        gasPrice: 15000000,      
        ovm: true // This sets the network as using the ovm and ensure contract will be compiled against that.
-    }
+    },
+    optimisticKovan: {
+      url: 'https://kovan.optimism.io',
+      // ********* Replace with your own mnemonic
+      accounts: { mnemonic: 'test test test test test test test test test test test junk' },
+      gasPrice: 15000000,
+      ovm: true // This sets the network as using the ovm and ensure contract will be compiled against that.
+   }    
   }
 };
 

--- a/truffle/README.md
+++ b/truffle/README.md
@@ -12,9 +12,11 @@ Ethereum mainnet itself, but are
 
 ## Build an Optimistic Ethereum Node
 
-The fastest way to test and debug apps on Optimistic Ethereum is to run a local Optimistic Ethereum node, so we'll build one.
-The directions in this section are for an Ubuntu 20.04 VM running on GCP with a 20 GB disk (the default, 10 GB, is not enough), 
-but they should be similar for other Linux versions and other platforms
+The fastest way to test and debug apps on Optimistic Ethereum is to run a 
+local Optimistic Ethereum node, so we'll build one.
+The directions in this section are for an Ubuntu 20.04 VM running on GCP with 
+a 20 GB disk (the default, 10 GB, is not enough) and 16 GB RAM
+but they should be similar for other Linux versions and other platforms.
 
 ### Install Prerequisite Software
 


### PR DESCRIPTION
**Description**

How to deploy to Kovan was asked multiple times in the discord channel. This is just the Hardhat because Truffle is more difficult.

Also, this update adds that the test environment should have 16 GB. I tried to use 8 GB, and it just hanged on me.