### PR TITLE
update standard token tutorial to v0.5

### DIFF
--- a/standard-bridge-standard-token/package.json
+++ b/standard-bridge-standard-token/package.json
@@ -14,7 +14,7 @@
     "hardhat": "^2.4.1"
   },
   "dependencies": {
-    "@eth-optimism/contracts": "^0.4.5",
+    "@eth-optimism/contracts": "^0.5.11",
     "dotenv": "^10.0.0"
   }
 }

--- a/standard-bridge-standard-token/scripts/deploy-standard-token.js
+++ b/standard-bridge-standard-token/scripts/deploy-standard-token.js
@@ -5,40 +5,50 @@
 // Runtime Environment's members available in the global scope.
 const hre = require("hardhat");
 
-const L2StandardTokenFactoryArtifact = require(`../node_modules/@eth-optimism/contracts/artifacts-ovm/contracts/optimistic-ethereum/OVM/bridge/tokens/OVM_L2StandardTokenFactory.sol/OVM_L2StandardTokenFactory.json`)
+const L2StandardTokenFactoryArtifact = require(`../node_modules/@eth-optimism/contracts/artifacts/contracts/L2/messaging/L2StandardTokenFactory.sol/L2StandardTokenFactory.json`);
 
 async function main() {
   // MODIFY TO DESIRED PARAMS
-  const L1TokenAddress = process.env.L1_TOKEN_ADDRESS
-  const L2TokenName = process.env.L2_TOKEN_NAME
-  const L2TokenSymbol = process.env.L2_TOKEN_SYMBOL
+  const L1TokenAddress = process.env.L1_TOKEN_ADDRESS;
+  const L2TokenName = process.env.L2_TOKEN_NAME;
+  const L2TokenSymbol = process.env.L2_TOKEN_SYMBOL;
 
   // Instantiate the signer
-  const provider = new ethers.providers.JsonRpcProvider(hre.network.config.url)
-  const signer = new ethers.Wallet(process.env.PRIVATE_KEY, provider)
+  const provider = new ethers.providers.JsonRpcProvider(hre.network.config.url);
+  const signer = new ethers.Wallet(process.env.PRIVATE_KEY, provider);
 
-  console.log("Creating instance of L2StandardERC20 on", hre.network.name, "network")
+  console.log(
+    "Creating instance of L2StandardERC20 on",
+    hre.network.name,
+    "network"
+  );
   // Instantiate the Standard token factory
-  const l2StandardTokenFactory = new ethers.Contract('0x4200000000000000000000000000000000000012', L2StandardTokenFactoryArtifact.abi, signer)
+  const l2StandardTokenFactory = new ethers.Contract(
+    "0x4200000000000000000000000000000000000012",
+    L2StandardTokenFactoryArtifact.abi,
+    signer
+  );
 
   const tx = await l2StandardTokenFactory.createStandardL2Token(
     L1TokenAddress,
     L2TokenName,
     L2TokenSymbol
-  )
-  const receipt = await tx.wait()
-  const args = receipt.events.find(({ event }) => event === 'StandardL2TokenCreated').args
+  );
+  const receipt = await tx.wait();
+  const args = receipt.events.find(
+    ({ event }) => event === "StandardL2TokenCreated"
+  ).args;
 
   // Get the L2 token address from the emmited event and log
-  const l2TokenAddress = args._l2Token
-  console.log("L2StandardERC20 deployed to:", l2TokenAddress)
+  const l2TokenAddress = args._l2Token;
+  console.log("L2StandardERC20 deployed to:", l2TokenAddress);
 }
 
 // We recommend this pattern to be able to use async/await everywhere
 // and properly handle errors.
 main()
   .then(() => process.exit(0))
-  .catch(error => {
+  .catch((error) => {
     console.error(error);
     process.exit(1);
-  })
+  });

--- a/standard-bridge-standard-token/yarn.lock
+++ b/standard-bridge-standard-token/yarn.lock
@@ -18,26 +18,26 @@
   resolved "https://registry.yarnpkg.com/@ensdomains/resolver/-/resolver-0.2.4.tgz#c10fe28bf5efbf49bff4666d909aed0265efbc89"
   integrity sha512-bvaTH34PMCbv6anRa9I/0zjLJgY4EuznbEMgbV77JBCQ9KNC46rzi0avuxpOfu+xDjPEtSFGqVEOr5GlUSGudA==
 
-"@eth-optimism/contracts@^0.4.5":
-  version "0.4.14"
-  resolved "https://registry.yarnpkg.com/@eth-optimism/contracts/-/contracts-0.4.14.tgz#e9b29f84e85d3db37e956c0df07c8af3d99e766d"
-  integrity sha512-E2IfkevM6DbTPhVpEvEo3Ws5tDWz5qmtGMzWZGSgZvcyC/GY0t0XKkZUUOrYDzYjOK9lAO21fa7WCPYP6Ay2IA==
+"@eth-optimism/contracts@^0.5.11":
+  version "0.5.11"
+  resolved "https://registry.yarnpkg.com/@eth-optimism/contracts/-/contracts-0.5.11.tgz#935a776be3f0d27dd26fa9e892c02c6b0fe86e93"
+  integrity sha512-W1xgY4qgJO9IHG1qOe98kjDMOH0mqpO3oiaSxeIFmzzshNiWGw3XSDbEvHqdsAapFYzfrmwavY3FAg7G5iqGEA==
   dependencies:
-    "@eth-optimism/core-utils" "^0.6.1"
+    "@eth-optimism/core-utils" "0.7.5"
     "@ethersproject/abstract-provider" "^5.4.1"
     "@ethersproject/abstract-signer" "^5.4.1"
-    "@ethersproject/contracts" "^5.4.1"
     "@ethersproject/hardware-wallets" "^5.4.0"
-    "@nomiclabs/hardhat-etherscan" "^2.1.5"
-    glob "^7.1.6"
 
-"@eth-optimism/core-utils@^0.6.1":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/@eth-optimism/core-utils/-/core-utils-0.6.1.tgz#ace2f9c31e995e48d1fa6229e3afaa7f4c53e11d"
-  integrity sha512-mTNEpUIaYXf+fSXxJCbWO9+1+vKzAPc3mC4TU3ukCfL19IdFf9ytG/9YKAM3Ls6bAhpwgKdIy1G+OEHvt4vxmA==
+"@eth-optimism/core-utils@0.7.5":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@eth-optimism/core-utils/-/core-utils-0.7.5.tgz#31b11171fdd816fd17459437f7ac67d26ebad422"
+  integrity sha512-rinXC0msmLipPAkxVzwkSGmmoCvd1WuYPYcBh3rKc5ZCroDZ0UpxTfjDwBB0lAWUQ04OH+/70RUFMENOn6WYUA==
   dependencies:
     "@ethersproject/abstract-provider" "^5.4.1"
+    "@ethersproject/bytes" "^5.5.0"
     "@ethersproject/providers" "^5.4.5"
+    "@ethersproject/web" "^5.5.0"
+    chai "^4.3.4"
     ethers "^5.4.5"
     lodash "^4.17.21"
 
@@ -217,7 +217,7 @@
     "@ethersproject/logger" "^5.5.0"
     "@ethersproject/properties" "^5.5.0"
 
-"@ethersproject/address@5.5.0", "@ethersproject/address@>=5.0.0-beta.128", "@ethersproject/address@^5.0.2", "@ethersproject/address@^5.5.0":
+"@ethersproject/address@5.5.0", "@ethersproject/address@>=5.0.0-beta.128", "@ethersproject/address@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/address/-/address-5.5.0.tgz#bcc6f576a553f21f3dd7ba17248f81b473c9c78f"
   integrity sha512-l4Nj0eWlTUh6ro5IbPTgbpT4wRbdH5l8CQf7icF7sb/SI3Nhd9Y9HzhonTSTi6CefI0necIw7LJqQPopPLZyWw==
@@ -266,7 +266,7 @@
   dependencies:
     "@ethersproject/bignumber" "^5.5.0"
 
-"@ethersproject/contracts@5.5.0", "@ethersproject/contracts@^5.4.1":
+"@ethersproject/contracts@5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@ethersproject/contracts/-/contracts-5.5.0.tgz#b735260d4bd61283a670a82d5275e2a38892c197"
   integrity sha512-2viY7NzyvJkh+Ug17v7g3/IJC8HqZBDcOjYARZLdzRxrfGlRgmYgl6xPRKVbEzy1dWKw/iv7chDcS83pg6cLxg==
@@ -625,19 +625,6 @@
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/@nomiclabs/hardhat-ethers/-/hardhat-ethers-2.0.2.tgz#c472abcba0c5185aaa4ad4070146e95213c68511"
   integrity sha512-6quxWe8wwS4X5v3Au8q1jOvXYEPkS1Fh+cME5u6AwNdnI4uERvPlVjlgRWzpnb+Rrt1l/cEqiNRH9GlsBMSDQg==
-
-"@nomiclabs/hardhat-etherscan@^2.1.5":
-  version "2.1.8"
-  resolved "https://registry.yarnpkg.com/@nomiclabs/hardhat-etherscan/-/hardhat-etherscan-2.1.8.tgz#e206275e96962cd15e5ba9148b44388bc922d8c2"
-  integrity sha512-0+rj0SsZotVOcTLyDOxnOc3Gulo8upo0rsw/h+gBPcmtj91YqYJNhdARHoBxOhhE8z+5IUQPx+Dii04lXT14PA==
-  dependencies:
-    "@ethersproject/abi" "^5.1.2"
-    "@ethersproject/address" "^5.0.2"
-    cbor "^5.0.2"
-    debug "^4.1.1"
-    fs-extra "^7.0.1"
-    node-fetch "^2.6.0"
-    semver "^6.3.0"
 
 "@nomiclabs/hardhat-waffle@^2.0.1":
   version "2.0.1"
@@ -2110,14 +2097,6 @@ caseless@~0.12.0:
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
-
-cbor@^5.0.2:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/cbor/-/cbor-5.2.0.tgz#4cca67783ccd6de7b50ab4ed62636712f287a67c"
-  integrity sha512-5IMhi9e1QU76ppa5/ajP1BmMWZ2FHkhAhjeVKQ/EFCgYSEaeVaoGtL7cxJskf9oCCk+XjzaIdc3IuU/dbA/o2A==
-  dependencies:
-    bignumber.js "^9.0.1"
-    nofilter "^1.0.4"
 
 chai@^4.3.4:
   version "4.3.4"
@@ -3883,7 +3862,7 @@ glob@7.1.3:
     once "^1.3.0"
     path-is-absolute "^1.0.0"
 
-glob@^7.1.2, glob@^7.1.3, glob@^7.1.6:
+glob@^7.1.2, glob@^7.1.3:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.2.0.tgz#d15535af7732e02e948f4c41628bd910293f6023"
   integrity sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==
@@ -5646,11 +5625,6 @@ node-hid@2.1.1:
     bindings "^1.5.0"
     node-addon-api "^3.0.2"
     prebuild-install "^6.0.0"
-
-nofilter@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/nofilter/-/nofilter-1.0.4.tgz#78d6f4b6a613e7ced8b015cec534625f7667006e"
-  integrity sha512-N8lidFp+fCz+TD51+haYdbDGrcBWwuHX40F5+z0qkUjMJ5Tp+rdSuAkMJ9N9eoolDlEVTf6u5icM+cNKkKW2mA==
 
 noop-logger@^0.1.1:
   version "0.1.1"


### PR DESCRIPTION
**Description**
The `standard-bridge-standard-token` tutorial was still using `v0.4.5` of `@eth-optimism/contracts`. This PR bumps that dependency (to catch up to `standard-bridge-custom-token`) and updates the deploy script to the new location of the dependencies.
