### PR TITLE
Fix network name in examples

### DIFF
--- a/cross-dom-comm/README.md
+++ b/cross-dom-comm/README.md
@@ -71,7 +71,7 @@ This setup assumes you already have [Node.js](https://nodejs.org/en/) and [yarn]
 
 
 
-### Optimism message to Etherscan
+### Optimism message to Ethereum
 
 #### Send the message
 
@@ -115,7 +115,7 @@ You can do it using [the Optimism SDK](https://www.npmjs.com/package/@eth-optimi
 1. Connect the Hardhat console to Kovan (L1):
 
    ```sh
-   yarn hardhat console --network optimistic-kovan
+   yarn hardhat console --network kovan
    ```
 
 1. Get the SDK (it is already in `node_modules`).


### PR DESCRIPTION


<!--
Please fill in each sections of this template, and delete any sections that are not relevant.

Need help?
Refer to our contributing guidelines for additional information about making a good pull request:
https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md
-->

**Description**
In the "receive message on Ethereum from Optimism" part, the first step should be connecting to L1 (kovan) instead of L2 (optimistic-kovan)

**Additional context**
This PR fixes small typos in the [cross-domain communication tutorial](https://github.com/ethereum-optimism/optimism-tutorial/tree/main/cross-dom-comm)