### PR TITLE
Updated Alchemy to preferred provider status on most tutorials

### DIFF
--- a/cross-dom-bridge/.env.example
+++ b/cross-dom-bridge/.env.example
@@ -1,5 +1,5 @@
 # Put the mnemonic for an account on Optimism here
 MNEMONIC="test test test test test test test test test test test junk"
-GOERLI_KEY=  <<value goes here>>
-OPTIMISM_GOERLI_KEY= <<value goes here>>
+GOERLI_ALCHEMY_KEY=  <<value goes here>>
+OPTIMISM_GOERLI_ALCHEMY_KEY= <<value goes here>>
 

--- a/cross-dom-bridge/.env.example
+++ b/cross-dom-bridge/.env.example
@@ -1,5 +1,5 @@
 # Put the mnemonic for an account on Optimism here
 MNEMONIC="test test test test test test test test test test test junk"
-GOERLI_URL=  <<url goes here>>
-OPTI_GOERLI_URL= <<url goes here>>
+GOERLI_KEY=  <<value goes here>>
+OPTIMISM_GOERLI_KEY= <<value goes here>>
 

--- a/cross-dom-bridge/README.md
+++ b/cross-dom-bridge/README.md
@@ -26,11 +26,18 @@ This tutorial teaches you how to use the [Optimism SDK](https://sdk.optimism.io/
    yarn
    ```
 
+1. Go to [Alchemy](https://www.alchemy.com/) and create two applications:
+
+   - An application on Goerli
+   - An application on Optimistic Goerli
+
+   Keep a copy of the two keys.
+
 1. Copy `.env.example` to `.env` and edit it:
 
-   1. Set `MNEMONIC` to point to an account that has ETH and DAI on the Kovan test network.
-   1. Set `GOERLI_URL` to point to a URL that accesses the Goerli test network.
-   1. Set `OPTI_GOERLI_URL` to point to the URL for [an Optimism endpoint](https://community.optimism.io/docs/useful-tools/networks/)
+   1. Set `MNEMONIC` to point to an account that has ETH on the Goerli test network and the Optimism Goerli test network.
+   1. Set `GOERLI_KEY` to the key for the Goerli app.
+   1. Set `OPTIMISM_GOERLI_KEY` to the key for the Optimistic Goerli app
 
    On the Goerli test network you can get ETH from [this faucet](https://faucet.paradigm.xyz/).
 
@@ -92,8 +99,8 @@ The libraries we need: [`ethers`](https://docs.ethers.io/v5/), [`dotenv`](https:
 
 ```js
 const mnemonic = process.env.MNEMONIC
-const l1Url = process.env.GOERLI_URL
-const l2Url = process.env.OPTI_GOERLI_URL
+const l1Url = `https://eth-goerli.g.alchemy.com/v2/${process.env.GOERLI_KEY}`
+const l2Url = `https://opt-goerli.g.alchemy.com/v2/${process.env.OPTIMISM_GOERLI_KEY}`
 ```
 
 Configuration, read from `.env`.

--- a/cross-dom-bridge/README.md
+++ b/cross-dom-bridge/README.md
@@ -36,8 +36,8 @@ This tutorial teaches you how to use the [Optimism SDK](https://sdk.optimism.io/
 1. Copy `.env.example` to `.env` and edit it:
 
    1. Set `MNEMONIC` to point to an account that has ETH on the Goerli test network and the Optimism Goerli test network.
-   1. Set `GOERLI_KEY` to the key for the Goerli app.
-   1. Set `OPTIMISM_GOERLI_KEY` to the key for the Optimistic Goerli app
+   1. Set `GOERLI_ALCHEMY_KEY` to the key for the Goerli app.
+   1. Set `OPTIMISM_GOERLI_ALCHEMY_KEY` to the key for the Optimistic Goerli app
 
    On the Goerli test network you can get ETH from [this faucet](https://faucet.paradigm.xyz/).
 

--- a/cross-dom-bridge/index.js
+++ b/cross-dom-bridge/index.js
@@ -1,4 +1,4 @@
-#! /usr/bin/node
+#! /usr/local/bin/node
 
 // Transfers between L1 and L2 using the Optimism SDK
 
@@ -8,8 +8,8 @@ require('dotenv').config()
 
 
 const mnemonic = process.env.MNEMONIC
-const l1Url = process.env.GOERLI_URL
-const l2Url = process.env.OPTI_GOERLI_URL
+const l1Url = `https://eth-goerli.g.alchemy.com/v2/${process.env.GOERLI_KEY}`
+const l2Url = `https://opt-goerli.g.alchemy.com/v2/${process.env.OPTIMISM_GOERLI_KEY}`
 
 
 // Contract addresses for DAI tokens, taken
@@ -47,8 +47,8 @@ const setup = async() => {
       l1SignerOrProvider: l1Signer,
       l2SignerOrProvider: l2Signer
   })
-  l1ERC20 = new ethers.Contract(daiAddrs.l1Addr, erc20ABI, l1Signer)
-  l2ERC20 = new ethers.Contract(daiAddrs.l2Addr, erc20ABI, l2Signer)
+//  l1ERC20 = new ethers.Contract(daiAddrs.l1Addr, erc20ABI, l1Signer)
+//  l2ERC20 = new ethers.Contract(daiAddrs.l2Addr, erc20ABI, l2Signer)
 }    // setup
 
 

--- a/cross-dom-bridge/index.js
+++ b/cross-dom-bridge/index.js
@@ -8,8 +8,8 @@ require('dotenv').config()
 
 
 const mnemonic = process.env.MNEMONIC
-const l1Url = `https://eth-goerli.g.alchemy.com/v2/${process.env.GOERLI_KEY}`
-const l2Url = `https://opt-goerli.g.alchemy.com/v2/${process.env.OPTIMISM_GOERLI_KEY}`
+const l1Url = `https://eth-goerli.g.alchemy.com/v2/${process.env.GOERLI_ALCHEMY_KEY}`
+const l2Url = `https://opt-goerli.g.alchemy.com/v2/${process.env.OPTIMISM_GOERLI_ALCHEMY_KEY}`
 
 
 // Contract addresses for DAI tokens, taken

--- a/cross-dom-comm/README.md
+++ b/cross-dom-comm/README.md
@@ -36,12 +36,19 @@ This is how you can see communication between domains work in hardhat.
 
 This setup assumes you already have [Node.js](https://nodejs.org/en/) and [yarn](https://classic.yarnpkg.com/) installed on your system. 
 
+1. Go to [Alchemy](https://www.alchemy.com/) and create two applications:
+
+   - An application on Goerli
+   - An application on Optimistic Goerli
+
+   Keep a copy of the two keys.
+
 1. Copy `.env.example` to `.env` and edit it:
 
-   1. Set `MNEMONIC` to point to an account that has ETH on the Goerli test network as well as the Optimistic Goerli test network.
-   1. Set `GOERLI_URL` to point to a URL that accesses the Goerli test network.
-   1. Set `OPTI_GOERLI_URL` to point to a URL that accesses the Goerli test network.   
-
+   1. Set `MNEMONIC` to point to an account that has ETH on the Goerli test network and the Optimism Goerli test network.
+   1. Set `GOERLI_KEY` to the key for the Goerli app.
+   1. Set `OPTIMISM_GOERLI_KEY` to the key for the Optimistic Goerli app
+   
 1. Install the necessary packages.
 
    ```sh
@@ -79,7 +86,7 @@ This setup assumes you already have [Node.js](https://nodejs.org/en/) and [yarn]
    ```js
    Controller = await ethers.getContractFactory("FromL1_ControlL2Greeter")
    controller = await Controller.deploy()
-   tx = await controller.setGreeting("Shalom")
+   tx = await controller.setGreeting(`Hello from L1 ${Date()}`)
    rcpt = await tx.wait()
    ```
 
@@ -126,7 +133,7 @@ This setup assumes you already have [Node.js](https://nodejs.org/en/) and [yarn]
    ```js
    Controller = await ethers.getContractFactory("FromL2_ControlL1Greeter")
    controller = await Controller.deploy()
-   tx = await controller.setGreeting("Shalom")
+tx = await controller.setGreeting(`Hello from L2 ${Date()}`)
    rcpt = await tx.wait()
    ```
 
@@ -166,11 +173,12 @@ You can do it using [the Optimism SDK](https://www.npmjs.com/package/@eth-optimi
 
    ```js
    l1Signer = await ethers.getSigner()
+   l2Url = `https://opt-goerli.g.alchemy.com/v2/${process.env.OPTIMISM_GOERLI_KEY}`
    crossChainMessenger = new sdk.CrossChainMessenger({ 
       l1ChainId: 5,
       l2ChainId: 420,
       l1SignerOrProvider: l1Signer, 
-      l2SignerOrProvider: new ethers.providers.JsonRpcProvider(process.env.OPTI_GOERLI_URL)
+      l2SignerOrProvider: new ethers.providers.JsonRpcProvider(l2Url)
    })
    ```
 
@@ -196,10 +204,22 @@ You can do it using [the Optimism SDK](https://www.npmjs.com/package/@eth-optimi
 1. Finalize the message.
 
    ```js
-   await crossChainMessenger.finalizeMessage(hash)
+   tx = await crossChainMessenger.finalizeMessage(hash)
+   rcpt = await tx.wait()
    ```
 
-1. To verify the change, [browse to the Greeter contract on Etherscan](https://goerli.etherscan.io/address/0x7fA4D972bB15B71358da2D937E4A830A9084cf2e#readContract) again and click **greet** to see the new greeting.
+1. Get the new L1 greeting. There are two ways to do that:
+
+   - [Browse to the Greeter contract on Etherscan](https://goerli.etherscan.io/address/0x7fA4D972bB15B71358da2D937E4A830A9084cf2e#readContract) and click **greet** to see the greeting.
+
+   - Run these commands in the Hardhat console connected to L1 Goerli:
+
+     ```js
+     Greeter = await ethers.getContractFactory("Greeter")
+     greeter = await Greeter.attach("0x7fA4D972bB15B71358da2D937E4A830A9084cf2e")
+     await greeter.greet()     
+     ```
+
 
 
 ### Foundry
@@ -213,7 +233,7 @@ You can do it using [the Optimism SDK](https://www.npmjs.com/package/@eth-optimi
    yarn
    ```
 
-1. Create environment variables for the URLs for Goerli and Optimistic Goerli:
+1. Create environment variables for the URLs for the Goerli and Optimism Goerli applications:
 
    ```sh
    cd ..

--- a/cross-dom-comm/README.md
+++ b/cross-dom-comm/README.md
@@ -46,8 +46,8 @@ This setup assumes you already have [Node.js](https://nodejs.org/en/) and [yarn]
 1. Copy `.env.example` to `.env` and edit it:
 
    1. Set `MNEMONIC` to point to an account that has ETH on the Goerli test network and the Optimism Goerli test network.
-   1. Set `GOERLI_KEY` to the key for the Goerli app.
-   1. Set `OPTIMISM_GOERLI_KEY` to the key for the Optimistic Goerli app
+   1. Set `GOERLI_ALCHEMY_KEY` to the key for the Goerli app.
+   1. Set `OPTIMISM_GOERLI_ALCHEMY_KEY` to the key for the Optimistic Goerli app
    
 1. Install the necessary packages.
 
@@ -97,7 +97,7 @@ This setup assumes you already have [Node.js](https://nodejs.org/en/) and [yarn]
    ```
 
 1. Back in the Optimism Goerli console, see the new greeting.
-   Note that it may take a few minutes to update.
+   Note that it may take a few minutes to update after the transaction is processed on L2.
 
    ```js
    await greeter.greet()
@@ -133,7 +133,7 @@ This setup assumes you already have [Node.js](https://nodejs.org/en/) and [yarn]
    ```js
    Controller = await ethers.getContractFactory("FromL2_ControlL1Greeter")
    controller = await Controller.deploy()
-tx = await controller.setGreeting(`Hello from L2 ${Date()}`)
+   tx = await controller.setGreeting(`Hello from L2 ${Date()}`)
    rcpt = await tx.wait()
    ```
 
@@ -173,7 +173,7 @@ You can do it using [the Optimism SDK](https://www.npmjs.com/package/@eth-optimi
 
    ```js
    l1Signer = await ethers.getSigner()
-   l2Url = `https://opt-goerli.g.alchemy.com/v2/${process.env.OPTIMISM_GOERLI_KEY}`
+   l2Url = `https://opt-goerli.g.alchemy.com/v2/${process.env.OPTIMISM_GOERLI_ALCHEMY_KEY}`
    crossChainMessenger = new sdk.CrossChainMessenger({ 
       l1ChainId: 5,
       l2ChainId: 420,

--- a/cross-dom-comm/hardhat/.env.example
+++ b/cross-dom-comm/hardhat/.env.example
@@ -1,3 +1,5 @@
-MNEMONIC= << your value here >>
-GOERLI_URL= << your value here >>
-OPTI_GOERLI_URL= << your value here >>
+# Put the mnemonic for an account on Optimism here
+MNEMONIC="test test test test test test test test test test test junk"
+GOERLI_KEY=  <<value goes here>>
+OPTIMISM_GOERLI_KEY= <<value goes here>>
+

--- a/cross-dom-comm/hardhat/.env.example
+++ b/cross-dom-comm/hardhat/.env.example
@@ -1,5 +1,5 @@
 # Put the mnemonic for an account on Optimism here
 MNEMONIC="test test test test test test test test test test test junk"
-GOERLI_KEY=  <<value goes here>>
-OPTIMISM_GOERLI_KEY= <<value goes here>>
+GOERLI_ALCHEMY_KEY=  <<value goes here>>
+OPTIMISM_GOERLI_ALCHEMY_KEY= <<value goes here>>
 

--- a/cross-dom-comm/hardhat/hardhat.config.js
+++ b/cross-dom-comm/hardhat/hardhat.config.js
@@ -12,8 +12,6 @@ task("accounts", "Prints the list of accounts", async (taskArgs, hre) => {
 });
 
 
-
-
 // You need to export an object to set up your config
 // Go to https://hardhat.org/config/ to learn more
 
@@ -24,11 +22,11 @@ module.exports = {
   solidity: "0.8.4",
   networks: {
      "optimism-goerli": {
-        url: process.env.OPTI_GOERLI_URL,
+        url: `https://opt-goerli.g.alchemy.com/v2/${process.env.OPTIMISM_GOERLI_KEY}`,
         accounts: { mnemonic: process.env.MNEMONIC }
       },
       "goerli": {
-        url: process.env.GOERLI_URL,
+        url: `https://eth-goerli.g.alchemy.com/v2/${process.env.GOERLI_KEY}`,
         accounts: { mnemonic: process.env.MNEMONIC }
       }
   } 

--- a/cross-dom-comm/hardhat/hardhat.config.js
+++ b/cross-dom-comm/hardhat/hardhat.config.js
@@ -22,11 +22,11 @@ module.exports = {
   solidity: "0.8.4",
   networks: {
      "optimism-goerli": {
-        url: `https://opt-goerli.g.alchemy.com/v2/${process.env.OPTIMISM_GOERLI_KEY}`,
+        url: `https://opt-goerli.g.alchemy.com/v2/${process.env.OPTIMISM_GOERLI_ALCHEMY_KEY}`,
         accounts: { mnemonic: process.env.MNEMONIC }
       },
       "goerli": {
-        url: `https://eth-goerli.g.alchemy.com/v2/${process.env.GOERLI_KEY}`,
+        url: `https://eth-goerli.g.alchemy.com/v2/${process.env.GOERLI_ALCHEMY_KEY}`,
         accounts: { mnemonic: process.env.MNEMONIC }
       }
   } 

--- a/getting-started/README.md
+++ b/getting-started/README.md
@@ -37,10 +37,12 @@ As you can see in the different development stacks below, the way you deploy con
 
 ## Hardhat
 
+In [Hardhat](https://hardhat.org/) you use a configuration similar to [this one](https://github.com/ethereum-optimism/optimism-tutorial/tree/main/getting-started/hardhat).
+
 ### Connecting to Optimism
 
-In [Hardhat](https://hardhat.org/) you use a configuration similar to [this one](https://github.com/ethereum-optimism/optimism-tutorial/tree/main/getting-started/hardhat).
-Here are the steps to create it:
+Follow these steps to add Optimism Goerli support to an existing Hardhat project. 
+
 
 1. Define your network configuration in `.env`:
 
@@ -115,7 +117,7 @@ Here are the steps to create it:
 1. Submit a transaction, wait for it to be processed, and see that it affected the state.
 
    ```js
-   tx = await greeter.setGreeting(`Hello ${new Date()}`)
+   tx = await greeter.setGreeting(`Hardhat: Hello ${new Date()}`)
    rcpt = await tx.wait()  
    await greeter.greet()
    ```
@@ -133,18 +135,24 @@ await greeter.greet()
 
 ## Truffle
 
+In [Truffle](https://trufflesuite.com/) you use a configuration similar to [this one](https://github.com/ethereum-optimism/optimism-tutorial/tree/main/getting-started/truffle).
+
 ### Connecting to Optimism
 
-In [Truffle](https://trufflesuite.com/):
+Follow these steps to add Optimism Goerli support to an existing Truffle project. 
+
 
 1. Define your network configuration in `.env`:
 
    ```sh
    # Put the mnemonic for an account on Optimism here
-   MNEMONIC="test test test test test test test test test test test junk"
+   MNEMONIC=test test test test test test test test test test test junk
 
-   # URL to access Optimism Goerli
-   OPTI_GOERLI_URL=https://goerli.optimism.io
+   # API KEY for Alchemy
+   ALCHEMY_API_KEY=
+
+   # URL to access Optimism Goerli (if not using Alchemy)
+   OPTIMISM_GOERLI_URL=
    ```
 
 1. Add `dotenv` and `@truffle/hdwallet-provider` to your project:
@@ -168,13 +176,23 @@ In [Truffle](https://trufflesuite.com/):
       require('dotenv').config()
       ```
 
+   1. Get the correct URL:
+
+      ```js
+      const optimismGoerliUrl =
+         process.env.ALCHEMY_API_KEY ?
+            `https://opt-goerli.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}` :
+            process.env.OPTIMISM_GOERLI_URL
+      ```
+
    1. Add a network definition in `module.exports.networks`:
 
       ```js
       "optimism-goerli": {
          provider: () => new HDWalletProvider(
             process.env.MNEMONIC,
-            process.env.OPTI_GOERLI_URL)
+            optimismGoerliUrl),
+         network_id: 420
       }
       ```
 
@@ -204,7 +222,7 @@ In [Truffle](https://trufflesuite.com/):
 1. Submit a transaction, wait for it to be processed, and see that it affected the state.
 
    ```js
-   tx = await greeter.setGreeting(`Hello ${new Date()}`)
+   tx = await greeter.setGreeting(`Truffle: Hello ${new Date()}`)
    await greeter.greet()
    ```
 
@@ -219,7 +237,7 @@ console.log(`Contract address: ${greeter.address}`)
 await greeter.greet()
 ```
 
-
+<!--
 ## Brownie
 
 [Brownie](https://eth-brownie.readthedocs.io/en/stable/install.html) is an Ethereum development environment, similar to Hardhat and Truffle, but using Python rather than JavaScript.
@@ -357,6 +375,8 @@ greeter = await Greeter.deploy("Greeter from hardhat")
 console.log(`Contract address: ${greeter.address}`)
 await greeter.greet()
 ```
+
+-->
 
 
 

--- a/getting-started/README.md
+++ b/getting-started/README.md
@@ -10,11 +10,10 @@ But a few differences [do exist](https://community.optimism.io/docs/developers/b
 
 ## Optimism endpoint URL
 
-To access any Ethereum type network you need an endpoint. There are several ways to get one:a free tier for low usage.
+To access any Ethereum type network you need an endpoint. 
+We recommend you get one from [Alchemy, our preferred provider](https://www.alchemy.com/).
 
-1. For *limited* development use, [Optimism-provided endpoints](https://community.optimism.io/docs/useful-tools/networks/). 
-   Note that these endpoints are rate limited, so they are not for use in QA or production environments.
-
+If you prefer, we have [other providers too](https://community.optimism.io/docs/useful-tools/providers/).
 
 
 
@@ -23,7 +22,7 @@ To access any Ethereum type network you need an endpoint. There are several ways
 
 For development purposes we recommend you use either a local development node or [Optimism Goerli](https://blockscout.com/optimism/goerli).
 That way you don't need to spend real money.
-If you need Goerli ETH for testing purposes, [you can use this faucet](https://faucet.paradigm.xyz/).
+If you need ETH on Optimism Goerli for testing purposes, [you can use this faucet](https://optimismfaucet.xyz/).
 
 The tests examples below all use Optimism Goerli.
 
@@ -33,23 +32,27 @@ The tests examples below all use Optimism Goerli.
 We have [Hardhat's Greeter contract](https://github.com/nomiclabs/hardhat/blob/master/packages/hardhat-core/sample-projects/basic/contracts/Greeter.sol) on Optimism Goerli, at address [0x106941459A8768f5A92b770e280555FAF817576f](https://blockscout.com/optimism/goerli/address/0x106941459A8768f5A92b770e280555FAF817576f). 
 You can verify your development stack configuration by interacting with it.
 
-As you can see in the different development stacks below, the way you deploy contracts and interact with them on Optimism is identical to the way you do it with L1 Ethereum.
+As you can see in the different development stacks below, the way you deploy contracts and interact with them on Optimism is almost identical to the way you do it with L1 Ethereum.
 
 
 ## Hardhat
 
 ### Connecting to Optimism
 
-In [Hardhat](https://hardhat.org/) you edit the `hardhat.config.js` file:
+In [Hardhat](https://hardhat.org/) you use a configuration similar to [this one](https://github.com/ethereum-optimism/optimism-tutorial/tree/main/getting-started/hardhat).
+Here are the steps to create it:
 
 1. Define your network configuration in `.env`:
 
    ```sh
    # Put the mnemonic for an account on Optimism here
-   MNEMONIC="test test test test test test test test test test test junk"
+   MNEMONIC=test test test test test test test test test test test junk
 
-   # URL to access Optimism Goerli
-   OPTI_GOERLI_URL=https://goerli.optimism.io
+   # API KEY for Alchemy
+   ALCHEMY_API_KEY=
+
+   # URL to access Optimism Goerli (if not using Alchemy)
+   OPTIMISM_GOERLI_URL=
    ```
 
 1. Add `dotenv` to your project:
@@ -66,15 +69,26 @@ In [Hardhat](https://hardhat.org/) you edit the `hardhat.config.js` file:
       require('dotenv').config()
       ```
 
+   1. Get the correct URL from the configuration:
+
+      ```js
+      const optimismGoerliUrl =
+         process.env.ALCHEMY_API_KEY ?
+            `https://opt-goerli.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}` :
+            process.env.OPTIMISM_GOERLI_URL
+      ```
+
 
    1. Add a network definition in `module.exports.networks`:
 
    ```js
-       "optimism-goerli": {
-          url: process.env.OPTI_GOERLI_URL,
-         accounts: { mnemonic: process.env.MNEMONIC }
-      }
+   "optimism-goerli": {
+      url: optimismGoerliUrl,
+      accounts: { mnemonic: process.env.MNEMONIC }
+   }   
    ```
+
+
 
 ### Greeter interaction
 
@@ -204,6 +218,147 @@ greeter = await Greeter.new("Greeter from Truffle")
 console.log(`Contract address: ${greeter.address}`)
 await greeter.greet()
 ```
+
+
+## Brownie
+
+[Brownie](https://eth-brownie.readthedocs.io/en/stable/install.html) is an Ethereum development environment, similar to Hardhat and Truffle, but using Python rather than JavaScript.
+
+
+### Connecting to Optimism
+
+1. Add the Goerli test network:
+
+   ```sh
+   brownie networks add "Optimistic Ethereum" optimism-goerli \
+      chainid=420 explorer=https://blockscout.com/optimism/goerli \
+      host= << Optimism Goerli URL >>
+   ```
+
+1. Initialize the Brownie project:
+
+   ```sh
+   brownie init
+   ```
+
+1. Create a file, `brownie-config.yaml`, with this content:
+
+   ```yml
+   console:
+      show_colors: false   
+   ```
+
+1.    
+
+1. Define your network configuration in `.env`:
+
+   ```sh
+   # Put the private key for an Optiumism account here
+   PRIVATE_KEY=dead60a7dead60a7dead60a7dead60a7dead60a7dead60a7dead60a7dead60a7
+
+   # URL to access Optimism Goerli
+   OPTI_GOERLI_URL=https://goerli.optimism.
+   ```
+
+
+1. Install the libraries:
+
+   ```sh
+   sudo pip3 install moodyeth python-dotenv
+   ```
+
+
+1. Run Python 3
+
+   ```sh
+   python3
+   ```
+
+
+1. Import the configuration
+
+   ```python
+   import os
+   from dotenv import load_dotenv
+
+   load_dotenv()   
+   ```
+
+
+1. Import the libraries:
+
+   ```python
+   import moody, moody.libeb
+   ```
+
+
+1. Obtain the Optimism configuration:
+
+   ```python
+   optConf = moody.conf.OptimisticEthereum()
+   ```
+
+
+1. Modify the configuration to access the test network:
+
+   ```python
+   optConf.chain_id = 420
+   optConf.network_name = 'OptimismGoerli'
+   optConf.rpc_url = os.getenv("OPTI_GOERLI_URL")
+   ```
+
+
+1. Create the connection object:
+
+   ```python
+   conn = moody.libeb.MiliDoS(optConf).Auth(os.getenv("PRIVATE_KEY"))
+   ```
+
+1. 
+
+
+### Greeter interaction
+
+1. Run the console:
+   ```sh
+   cd hardhat
+   yarn
+   yarn hardhat console --network optimism-goerli
+   ```
+
+1. Connect to the Greeter contract:   
+
+   ```js
+   Greeter = await ethers.getContractFactory("Greeter")
+   greeter = await Greeter.attach("0x106941459A8768f5A92b770e280555FAF817576f")
+   ```   
+
+1. Read information from the contract:
+
+   ```js
+   await greeter.greet()
+   ```
+
+1. Submit a transaction, wait for it to be processed, and see that it affected the state.
+
+   ```js
+   tx = await greeter.setGreeting(`Hello ${new Date()}`)
+   rcpt = await tx.wait()  
+   await greeter.greet()
+   ```
+
+### Deploying a contract
+
+To deploy a contract from the Hardhat console:
+
+```
+Greeter = await ethers.getContractFactory("Greeter")
+greeter = await Greeter.deploy("Greeter from hardhat")
+console.log(`Contract address: ${greeter.address}`)
+await greeter.greet()
+```
+
+
 
 
 ## Remix
@@ -402,6 +557,8 @@ The tutorial makes these assumptions:
    You should see 2 tests passing.
 
 1. Play around with the code! Check out other available matchers in the [Waffle documentation](https://ethereum-waffle.readthedocs.io/en/latest/).
+
+
 
 ### Compatibility with other tools
 

--- a/getting-started/hardhat/.env.example
+++ b/getting-started/hardhat/.env.example
@@ -1,5 +1,8 @@
 # Put the mnemonic for an account on Optimism here
-MNEMONIC="test test test test test test test test test test test junk"
+MNEMONIC=test test test test test test test test test test test junk
 
-# URL to access Optimism Goerli
-OPTI_GOERLI_URL=https://goerli.optimism.io
+# API KEY for Alchemy
+ALCHEMY_API_KEY=
+
+# URL to access Optimism Goerli (if not using Alchemy)
+OPTIMISM_GOERLI_URL=

--- a/getting-started/hardhat/hardhat.config.js
+++ b/getting-started/hardhat/hardhat.config.js
@@ -17,6 +17,12 @@ task("accounts", "Prints the list of accounts", async (taskArgs, hre) => {
 /**
  * @type import('hardhat/config').HardhatUserConfig
  */
+
+const optimismGoerliUrl = 
+  process.env.ALCHEMY_API_KEY ? 
+    `https://opt-goerli.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}` :
+    process.env.OPTIMISM_GOERLI_URL
+
 module.exports = {
   solidity: "0.8.13",
   networks: {
@@ -25,7 +31,7 @@ module.exports = {
        accounts: { mnemonic: "test test test test test test test test test test test junk" }
     },
     "optimism-goerli": {
-       url: process.env.OPTI_GOERLI_URL,
+       url: optimismGoerliUrl,
        accounts: { mnemonic: process.env.MNEMONIC }
     }
   }

--- a/getting-started/truffle/.env.example
+++ b/getting-started/truffle/.env.example
@@ -1,5 +1,8 @@
 # Put the mnemonic for an account on Optimism here
-MNEMONIC="test test test test test test test test test test test junk"
+MNEMONIC=test test test test test test test test test test test junk
 
-# URL to access Optimism Goerli
-OPTI_GOERLI_URL=https://goerli.optimism.io
+# API KEY for Alchemy
+ALCHEMY_API_KEY=
+
+# URL to access Optimism Goerli (if not using Alchemy)
+OPTIMISM_GOERLI_URL=

--- a/getting-started/truffle/truffle-config.js
+++ b/getting-started/truffle/truffle-config.js
@@ -21,6 +21,12 @@
 const HDWalletProvider = require('@truffle/hdwallet-provider');
 require('dotenv').config()
 
+      
+const optimismGoerliUrl =
+    process.env.ALCHEMY_API_KEY ?
+        `https://opt-goerli.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}` :
+        process.env.OPTIMISM_GOERLI_URL
+
 
 module.exports = {
   /**
@@ -73,7 +79,7 @@ module.exports = {
     "optimism-goerli": {
       provider: () => new HDWalletProvider(
          process.env.MNEMONIC,
-         process.env.OPTI_GOERLI_URL),
+         optimismGoerliUrl),
       network_id: 420
    }
     // Useful for private networks

--- a/sdk-estimate-gas/.env.example
+++ b/sdk-estimate-gas/.env.example
@@ -1,5 +1,8 @@
 # Put the mnemonic for an account on Optimism here
-MNEMONIC="test test test test test test test test test test test junk"
+MNEMONIC=test test test test test test test test test test test junk
 
-# Put the URL for an Optimism (or Optimism Goerli) network here
-L2_URL=https://goerli.optimism.io
+# API KEY for Alchemy
+ALCHEMY_API_KEY=
+
+# URL to access Optimism Goerli (if not using Alchemy)
+OPTIMISM_GOERLI_URL=

--- a/sdk-estimate-gas/README.md
+++ b/sdk-estimate-gas/README.md
@@ -30,8 +30,10 @@ This calculation is complicated by the fact that the major cost is the cost of w
 
    - `MNEMONIC` is the mnemonic to an account that has enough ETH to pay for the transaction.
 
-   - `L2_URL` is a URL to an L2 network, either Optimism or Optimism Goerli. 
-     You can get such an endpoint from [any of these providers](https://community.optimism.io/docs/useful-tools/providers/).
+   - `ALCHEMY_API_KEY` is the API key for an Optimism Goerli app on [Alchemy](https://www.alchemy.com/), our preferred provider.
+
+   - `OPTIMISM_GOERLI_URL` is the URL for Optimism Goerli, if you use [a different node provider](https://community.optimism.io/docs/useful-tools/providers/).
+
 
 1. Use Node to run the script
 
@@ -137,11 +139,20 @@ const sleep = ms => new Promise(resp => setTimeout(resp, ms));
 The `sleep` function pauses execution for that number of milliseconds. 
 
 ```js
-// Get an L2 signer
 const getSigner = async () => {
+  const optimismGoerliUrl = 
+  process.env.ALCHEMY_API_KEY ? 
+    `https://opt-goerli.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}` :
+    process.env.OPTIMISM_GOERLI_URL
+
     const l2RpcProvider = optimismSDK.asL2Provider(
-      new ethers.providers.JsonRpcProvider(process.env.L2_URL)
+      new ethers.providers.JsonRpcProvider(optimismGoerliUrl)
     )
+    const wallet = ethers.Wallet.fromMnemonic(process.env.MNEMONIC).
+      connect(l2RpcProvider)
+
+    return wallet
+}   // getSigner
 ```
 
 The function [`optimismSDK.asL2Provider`](https://sdk.optimism.io/modules.html#asL2Provider) takes a regular [Ethers.js Provider](https://docs.ethers.io/v5/api/providers/) and adds a few L2 specific functions, which are explained below.

--- a/sdk-estimate-gas/gas.js
+++ b/sdk-estimate-gas/gas.js
@@ -25,8 +25,13 @@ const sleep = ms => new Promise(resp => setTimeout(resp, ms));
 
 // Get an L2 signer
 const getSigner = async () => {
+  const optimismGoerliUrl = 
+  process.env.ALCHEMY_API_KEY ? 
+    `https://opt-goerli.g.alchemy.com/v2/${process.env.ALCHEMY_API_KEY}` :
+    process.env.OPTIMISM_GOERLI_URL
+
     const l2RpcProvider = optimismSDK.asL2Provider(
-      new ethers.providers.JsonRpcProvider(process.env.L2_URL)
+      new ethers.providers.JsonRpcProvider(optimismGoerliUrl)
     )
     const wallet = ethers.Wallet.fromMnemonic(process.env.MNEMONIC).
       connect(l2RpcProvider)


### PR DESCRIPTION
* Getting started:
   * Hardhat
   * Truffle
* Cross-domain bridge
* Cross-domain communication
* SDK estimate gas

Not done (and why):
* Getting started Remix, Foundry, and Waffle: Remix already has it, Foundry and Waffle are easier to do with the URL than with an API key
* SDK view tx: Complex enough with needing two URLs (L1 and L2), which can be either mainnet or Goerli
* standard-bridge-custom-token and standard-bridge-standard-token: Need to rewrite those soon anyway (when we have our new token process).

Closing: DOCS-638