### PR TITLE
feat(*): Remove links to old (pre-Bedrock) tutorial

### DIFF
--- a/cross-dom-bridge-erc20/README.md
+++ b/cross-dom-bridge-erc20/README.md
@@ -8,9 +8,6 @@ While you *could* use [the bridge contracts](https://community.optimism.io/docs/
 The SDK provides transparent safety rails to prevent that mistake.
 
 
-**Note:** This tutorial is for the Bedrock release, which is currently running on the Optimism Goerli test network, but not on the production network.
-Here is the [pre-Bedrock tutorial](https://github.com/ethereum-optimism/optimism-tutorial/tree/01e4f94fa2671cfed0c6c82257345f77b3b858ef/cross-dom-bridge-erc20).
-
 
 **Warning:** The standard bridge does *not* support certain ERC-20 configurations:
 
@@ -237,7 +234,6 @@ Get the signers we need, and our address.
 
 Create the [`CrossChainMessenger`](https://sdk.optimism.io/classes/crosschainmessenger) object that we use to transfer assets.
 At the current version of the SDK we need to specify that it is a bedrock transaction.
-After the production network is upgraded to bedrock, that will be the default.
 
 
 ```js

--- a/cross-dom-bridge-eth/README.md
+++ b/cross-dom-bridge-eth/README.md
@@ -5,8 +5,7 @@
 
 This tutorial teaches you how to use the [Optimism SDK](https://sdk.optimism.io/) to transfer ETH between Layer 1 (Ethereum) and Layer 2 (Optimism).
 
-**Note:** This tutorial is for the Bedrock release, which is currently running on the Optimism Goerli test network, but not on the production network.
-Here is the [pre-Bedrock tutorial](https://github.com/ethereum-optimism/optimism-tutorial/tree/01e4f94fa2671cfed0c6c82257345f77b3b858ef/cross-dom-bridge-eth).
+
 
 ## Setup
 

--- a/cross-dom-comm/README.md
+++ b/cross-dom-comm/README.md
@@ -12,9 +12,6 @@ This tutorial focuses on sending and receiving messages.
 If you want to trace transactions, [see the tracing tutorial](../sdk-trace-tx/).
 
 
-**Note:** This tutorial is for the Bedrock release, which is currently running on the Optimism Goerli test network, but not on the production network.
-Here is the [pre-Bedrock tutorial](https://github.com/ethereum-optimism/optimism-tutorial/tree/01e4f94fa2671cfed0c6c82257345f77b3b858ef/cross-dom-comm).
-
 ## Seeing it in action
 
 To show how this works we installed [a slightly modified version of HardHat's `Greeter.sol`](hardhat/contracts/Greeter.sol) on both L1 Goerli and Optimism Goerli.

--- a/getting-started/README.md
+++ b/getting-started/README.md
@@ -30,7 +30,6 @@ For development purposes we recommend you use either a local development node or
 That way you don't need to spend real money.
 If you need ETH on Optimism Goerli for testing purposes, [you can use this faucet](https://optimismfaucet.xyz/).
 
-The tests examples below all use either Optimism Goerli or the Optimism Bedrock beta testnet.
 
 
 ## Interacting with Optimism contracts

--- a/standard-bridge-custom-token/README.md
+++ b/standard-bridge-custom-token/README.md
@@ -11,8 +11,6 @@ The contract on the bridged layer has to implement either the legacy [`IL2Standa
 For this to be done securely, the *only* entity that is allowed to mint and burn tokens on the bridged layer has to be the Standard Bridge, to ensure that the tokens on the bridged layer are backed up by real tokens on the layer of original mint. 
 It is also necessary that the ERC-20 token contract on the layer of original mint *not* implement either of the interfaces, to make sure the bridge contracts don't get confused and think it is the bridged layer.
 
-**Note:** This tutorial is for the Bedrock release, which is currently running on the Optimism Goerli test network, but not on the production network. Here is the [pre-Bedrock tutorial](https://github.com/ethereum-optimism/optimism-tutorial/tree/01e4f94fa2671cfed0c6c82257345f77b3b858ef/standard-bridge-custom-token).
-
 **Warning:** The standard bridge does *not* support certain ERC-20 configurations:
 
 - [Fee on transfer tokens](https://github.com/d-xo/weird-erc20#fee-on-transfer)

--- a/standard-bridge-standard-token/README.md
+++ b/standard-bridge-standard-token/README.md
@@ -10,7 +10,6 @@ For an L1/L2 token pair to work on the Standard Bridge the L2 token contract mus
 If you do not need any special processing on L2, just the ability to deposit, transfer, and withdraw tokens, you can use [`OptimismMintableERC20Factory`](https://github.com/ethereum-optimism/optimism/blob/develop/packages/contracts-bedrock/contracts/universal/OptimismMintableERC20Factory.sol).
 
 
-**Note:** This tutorial is for the Bedrock release, which is currently running on the Optimism Goerli test network, but not on the production network. Here is the [pre-Bedrock tutorial](https://github.com/ethereum-optimism/optimism-tutorial/tree/01e4f94fa2671cfed0c6c82257345f77b3b858ef/standard-bridge-standard-token).
 
 **Warning:** The standard bridge does *not* support certain ERC-20 configurations:
 


### PR DESCRIPTION
Part of the bedrock upgrade, to be merged June 6th.

Closing: DEVRL-928
