### PR TITLE
fix: testnet faucet website

### DIFF
--- a/getting-started/README.md
+++ b/getting-started/README.md
@@ -28,7 +28,7 @@ Alternatively, we have [other great providers](https://community.optimism.io/doc
 
 For development purposes we recommend you use either a local development node or [Optimism Goerli](https://goerli-explorer.optimism.io/).
 That way you don't need to spend real money.
-If you need ETH on OP Goerli for testing purposes, [you can use this faucet](https://optimismfaucet.xyz/).
+If you need ETH on OP Goerli for testing purposes, [you can use this faucet](https://app.optimism.io/faucet).
 
 
 


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

The testnet faucet documented https://optimismfaucet.xyz/ seems to be no longer valid.

I updated with the correct one https://app.optimism.io/faucet

**Tests**

No need to test

**Additional context**

No additional context

**Metadata**
